### PR TITLE
Ephemeral

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ This is a course project, which includes three major parts: Faas platform, Warbl
   - [Run unit tests](#run-unit-tests)
   - [Execution Sequence](#execution-sequence)
 - [Usage: Run Warble Application](#usage-run-warble-application)
+- [Refactor in Phase 2](#refactor-in-phase-2)
+  - [Ephemeral warble code](#ephemeral-warble-code)
+  - [Key-value store disk persistence](#key-value-store-disk-persistence)
 
-# Setup Environmnt
+# Setup Environment
 
 ## Setup Vagrant box
 
@@ -233,3 +236,16 @@ Now, we could start run warble application.
 - Read User's Profile
 
   e.g.: ./warble --user "user_name" --profile
+
+# Refactor in Phase 2
+
+## Ephemeral warble code
+
+Two changes are done to make my warble code ephemeral.
+
+\- Directly pass storage pointer in to each warble function instead of storing it as a member variable of warble class.
+
+\- Substitute the incremental index for new warbles' index in warble class with a random generate id for each new warble.
+
+## Key-value store disk persistence
+

--- a/src/Func/CMakeLists.txt
+++ b/src/Func/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(
 )
 
 # Func Service
-add_executable(func_server func_service.cc func_platform.cc func_platform.h storage_abstraction.h keyvaluestore_client.cc keyvaluestore_client.h ../Warble/warble_service_abstraction.h ../Warble/warble_service.cc ../Warble/warble_service.h ../Warble/profile.h)
+add_executable(func_server func_service.cc func_platform.cc func_platform.h storage_abstraction.h keyvaluestore_client.cc keyvaluestore_client.h ../Warble/warble_service_abstraction.h ../Warble/warble_service.cc ../Warble/warble_service.h ../Warble/profile.h ../Warble/random_generator.cc ../Warble/random_generator.h)
 
 # KeyValue Client
 

--- a/src/Func/func_platform.cc
+++ b/src/Func/func_platform.cc
@@ -34,7 +34,7 @@ PayloadOptional FuncPlatform::Execute(const EventType &event_type,
   }
 
   FunctionType func = kFunctionMap.at(functionName);
-  PayloadOptional reply_payload_opt = func(*warble_service_, payload);
+  PayloadOptional reply_payload_opt = func(*warble_service_, payload, kv_store_);
   return reply_payload_opt;
 }
 }  // namespace cs499_fei

--- a/src/Func/func_platform.cc
+++ b/src/Func/func_platform.cc
@@ -34,7 +34,8 @@ PayloadOptional FuncPlatform::Execute(const EventType &event_type,
   }
 
   FunctionType func = kFunctionMap.at(functionName);
-  PayloadOptional reply_payload_opt = func(*warble_service_, payload, kv_store_);
+  PayloadOptional reply_payload_opt =
+      func(*warble_service_, payload, kv_store_);
   return reply_payload_opt;
 }
 }  // namespace cs499_fei

--- a/src/Func/func_platform.h
+++ b/src/Func/func_platform.h
@@ -43,7 +43,7 @@ using WarblePtr = std::shared_ptr<WarbleServiceAbstraction>;
 using EventType = unsigned int;
 using FunctionName = std::string;
 using FunctionType =
-    std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>;
+    std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>;
 
 using EventFuncNameMap = std::unordered_map<unsigned int, std::string>;
 using StrFuncPair = std::unordered_map<std::string, FunctionType>;
@@ -56,19 +56,19 @@ const std::string kFunctionProfile = "profile";
 
 const StrFuncPair kFunctionMap = {
     {kFunctionRegister,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>(
+     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
          &WarbleServiceAbstraction::RegisterUser)},
     {kFunctionWarble,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>(
+     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
          &WarbleServiceAbstraction::WarbleText)},
     {kFunctionFollow,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>(
+     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
          &WarbleServiceAbstraction::Follow)},
     {kFunctionRead,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>(
+     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
          &WarbleServiceAbstraction::ReadThread)},
     {kFunctionProfile,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload)>(
+     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
          &WarbleServiceAbstraction::ReadProfile)}};
 // Faas platform support three features:
 // 1. Event Management: Registration and removal if installed

--- a/src/Func/func_platform.h
+++ b/src/Func/func_platform.h
@@ -55,21 +55,21 @@ const std::string kFunctionRead = "read";
 const std::string kFunctionProfile = "profile";
 
 const StrFuncPair kFunctionMap = {
-    {kFunctionRegister,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
-         &WarbleServiceAbstraction::RegisterUser)},
-    {kFunctionWarble,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
-         &WarbleServiceAbstraction::WarbleText)},
-    {kFunctionFollow,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
-         &WarbleServiceAbstraction::Follow)},
-    {kFunctionRead,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
-         &WarbleServiceAbstraction::ReadThread)},
-    {kFunctionProfile,
-     std::function<PayloadOptional(WarbleServiceAbstraction &, Payload, StoragePtr)>(
-         &WarbleServiceAbstraction::ReadProfile)}};
+    {kFunctionRegister, std::function<PayloadOptional(
+                            WarbleServiceAbstraction &, Payload, StoragePtr)>(
+                            &WarbleServiceAbstraction::RegisterUser)},
+    {kFunctionWarble, std::function<PayloadOptional(WarbleServiceAbstraction &,
+                                                    Payload, StoragePtr)>(
+                          &WarbleServiceAbstraction::WarbleText)},
+    {kFunctionFollow, std::function<PayloadOptional(WarbleServiceAbstraction &,
+                                                    Payload, StoragePtr)>(
+                          &WarbleServiceAbstraction::Follow)},
+    {kFunctionRead, std::function<PayloadOptional(WarbleServiceAbstraction &,
+                                                  Payload, StoragePtr)>(
+                        &WarbleServiceAbstraction::ReadThread)},
+    {kFunctionProfile, std::function<PayloadOptional(WarbleServiceAbstraction &,
+                                                     Payload, StoragePtr)>(
+                           &WarbleServiceAbstraction::ReadProfile)}};
 // Faas platform support three features:
 // 1. Event Management: Registration and removal if installed
 // 2. Execute handler function in Warble.

--- a/src/Func/func_service.cc
+++ b/src/Func/func_service.cc
@@ -53,7 +53,7 @@ void RunServer() {
   StoragePtr storage_ptr =
       std::shared_ptr<KeyValueStoreClient>(new KeyValueStoreClient(channel));
   WarblePtr warble_ptr =
-      std::shared_ptr<WarbleService>(new WarbleService(storage_ptr));
+      std::shared_ptr<WarbleService>(new WarbleService());
 
   std::string server_address("0.0.0.0:50001");
   FuncServiceImpl func_service(storage_ptr, warble_ptr);

--- a/src/Func/func_service.cc
+++ b/src/Func/func_service.cc
@@ -52,8 +52,7 @@ void RunServer() {
                                      grpc::InsecureChannelCredentials());
   StoragePtr storage_ptr =
       std::shared_ptr<KeyValueStoreClient>(new KeyValueStoreClient(channel));
-  WarblePtr warble_ptr =
-      std::shared_ptr<WarbleService>(new WarbleService());
+  WarblePtr warble_ptr = std::shared_ptr<WarbleService>(new WarbleService());
 
   std::string server_address("0.0.0.0:50001");
   FuncServiceImpl func_service(storage_ptr, warble_ptr);

--- a/src/Warble/random_generator.cc
+++ b/src/Warble/random_generator.cc
@@ -1,0 +1,16 @@
+#include "random_generator.h"
+
+#include <iostream>
+#include <random>
+
+namespace cs499_fei {
+uint32_t randomID() {
+  std::random_device rd;
+  std::mt19937 engine{rd()};
+  std::uniform_int_distribution<uint32_t> distribution(
+      0, std::numeric_limits<uint32_t>::max());
+
+  // get random numbers with:
+  return distribution(engine);
+}
+}  // namespace cs499_fei

--- a/src/Warble/random_generator.h
+++ b/src/Warble/random_generator.h
@@ -1,0 +1,10 @@
+#ifndef CSCI499_FEI_SRC_WARBLE_RANDOM_GENERATOR_H_
+#define CSCI499_FEI_SRC_WARBLE_RANDOM_GENERATOR_H_
+
+#include <stdint.h>
+
+namespace cs499_fei {
+uint32_t randomID();
+}
+
+#endif  // CSCI499_FEI_SRC_WARBLE_RANDOM_GENERATOR_H_

--- a/src/Warble/warble_service.cc
+++ b/src/Warble/warble_service.cc
@@ -207,8 +207,8 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload,
     }
   }
 
-  std::string current_warble_id = std::to_string(warble_id_);
-  warble_id_++;
+  uint32_t warble_id = randomID();
+  std::string current_warble_id = std::to_string(warble_id);
 
   Warble new_warble;
   new_warble.set_username(user_name);

--- a/src/Warble/warble_service.cc
+++ b/src/Warble/warble_service.cc
@@ -17,7 +17,7 @@ StringVector deserialize(const std::string &s, char delim) {
   return res;
 }
 
-PayloadOptional WarbleService::RegisterUser(const Payload &payload) {
+PayloadOptional WarbleService::RegisterUser(const Payload &payload, const StoragePtr &kv_store) {
   RegisteruserRequest request;
   payload.UnpackTo(&request);
 
@@ -30,7 +30,7 @@ PayloadOptional WarbleService::RegisterUser(const Payload &payload) {
   std::string user_followings_key =
       kUserFollowingsPrefix + kUserPrefix + user_name;
   StringVector keys_vector = {user_warbles_key};
-  StringOptional user_warbles = kv_store_->Get(keys_vector).at(0);
+  StringOptional user_warbles = kv_store->Get(keys_vector).at(0);
 
   bool is_user_exist =
       (user_warbles.has_value()) && (!user_warbles.value().empty());
@@ -43,13 +43,13 @@ PayloadOptional WarbleService::RegisterUser(const Payload &payload) {
     return PayloadOptional();
   }
 
-  kv_store_->Put(user_warbles_key, kInit);
-  kv_store_->Put(user_followers_key, kInit);
-  kv_store_->Put(user_followings_key, kInit);
+  kv_store->Put(user_warbles_key, kInit);
+  kv_store->Put(user_followers_key, kInit);
+  kv_store->Put(user_followings_key, kInit);
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::Follow(const Payload &payload) {
+PayloadOptional WarbleService::Follow(const Payload &payload, const StoragePtr &kv_store) {
   FollowRequest request;
   payload.UnpackTo(&request);
 
@@ -64,7 +64,7 @@ PayloadOptional WarbleService::Follow(const Payload &payload) {
   key_vector.push_back(user_followings_key);
   key_vector.push_back(to_follow_followers_key);
 
-  StringOptionalVector value_vector = kv_store_->Get(key_vector);
+  StringOptionalVector value_vector = kv_store->Get(key_vector);
   StringOptional user_followings = value_vector.at(0);
   StringOptional to_follow_followers = value_vector.at(1);
 
@@ -92,8 +92,8 @@ PayloadOptional WarbleService::Follow(const Payload &payload) {
         to_follow_followers.value() + "," + new_to_follow_followers;
   }
 
-  kv_store_->Put(user_followings_key, new_user_followings);
-  kv_store_->Put(to_follow_followers_key, new_to_follow_followers);
+  kv_store->Put(user_followings_key, new_user_followings);
+  kv_store->Put(to_follow_followers_key, new_to_follow_followers);
 
   FollowReply reply;
   Payload reply_payload;
@@ -101,7 +101,7 @@ PayloadOptional WarbleService::Follow(const Payload &payload) {
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::ReadProfile(const Payload &payload) {
+PayloadOptional WarbleService::ReadProfile(const Payload &payload, const StoragePtr &kv_store) {
   ProfileRequest request;
   payload.UnpackTo(&request);
 
@@ -114,7 +114,7 @@ PayloadOptional WarbleService::ReadProfile(const Payload &payload) {
   key_vector.push_back(user_followings_key);
   key_vector.push_back(user_followers_key);
 
-  StringOptionalVector value_vector = kv_store_->Get(key_vector);
+  StringOptionalVector value_vector = kv_store->Get(key_vector);
   StringOptional user_followings = value_vector.at(0);
   StringOptional user_followers = value_vector.at(1);
 
@@ -153,7 +153,7 @@ PayloadOptional WarbleService::ReadProfile(const Payload &payload) {
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::WarbleText(const Payload &payload) {
+PayloadOptional WarbleService::WarbleText(const Payload &payload, const StoragePtr &kv_store) {
   timeval time;
   gettimeofday(&time, NULL);
 
@@ -179,7 +179,7 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload) {
     key_vector.push_back(warble_key);
   }
 
-  StringOptionalVector value_vector = kv_store_->Get(key_vector);
+  StringOptionalVector value_vector = kv_store->Get(key_vector);
 
   // Check whether user_name has been registered.
   StringOptional user_warbles = value_vector.at(0);
@@ -215,14 +215,14 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload) {
   new_warble.mutable_timestamp()->set_useconds(time.tv_usec);
 
   std::string warble_key = kWarblePrefix + current_warble_id;
-  kv_store_->Put(warble_key, new_warble.SerializeAsString());
+  kv_store->Put(warble_key, new_warble.SerializeAsString());
 
   std::string new_user_warbles = current_warble_id;
   if ((user_warbles != std::nullopt) && (user_warbles.value() != kInit)) {
     new_user_warbles = user_warbles.value() + "," + new_user_warbles;
   }
 
-  kv_store_->Put(user_warble_key, new_user_warbles);
+  kv_store->Put(user_warble_key, new_user_warbles);
 
   if (reply_to != "") {
     StringOptional warble_thread = value_vector.at(1);
@@ -230,7 +230,7 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload) {
     if ((warble_thread != std::nullopt) && (warble_thread.value() != "")) {
       new_warble_thread = warble_thread.value() + "," + new_warble_thread;
     }
-    kv_store_->Put(warble_thread_key, new_warble_thread);
+    kv_store->Put(warble_thread_key, new_warble_thread);
   }
 
   WarbleReply reply;
@@ -241,7 +241,7 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload) {
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::ReadThread(const Payload &payload) {
+PayloadOptional WarbleService::ReadThread(const Payload &payload, const StoragePtr &kv_store) {
   ReadRequest request;
   payload.UnpackTo(&request);
   std::string warble_id = request.warble_id();
@@ -251,7 +251,7 @@ PayloadOptional WarbleService::ReadThread(const Payload &payload) {
       kWarbleThreadPrefix + kWarblePrefix + warble_id;
   std::string warble_key = kWarblePrefix + warble_id;
   StringVector key_vector = {warble_thread_key, warble_key};
-  StringOptionalVector value_vector = kv_store_->Get(key_vector);
+  StringOptionalVector value_vector = kv_store->Get(key_vector);
   StringOptional warble_ids_opt = value_vector.at(0);
   StringOptional warble = value_vector.at(1);
 
@@ -285,7 +285,7 @@ PayloadOptional WarbleService::ReadThread(const Payload &payload) {
   for (auto s : warble_ids_vector) {
     key_vector.push_back(kWarblePrefix + s);
   }
-  StringOptionalVector warbles_opt_vector = kv_store_->Get(key_vector);
+  StringOptionalVector warbles_opt_vector = kv_store->Get(key_vector);
   for (auto op : warbles_opt_vector) {
     auto w = reply.add_warbles();
     w->ParseFromString(op.value());

--- a/src/Warble/warble_service.cc
+++ b/src/Warble/warble_service.cc
@@ -17,7 +17,8 @@ StringVector deserialize(const std::string &s, char delim) {
   return res;
 }
 
-PayloadOptional WarbleService::RegisterUser(const Payload &payload, const StoragePtr &kv_store) {
+PayloadOptional WarbleService::RegisterUser(const Payload &payload,
+                                            const StoragePtr &kv_store) {
   RegisteruserRequest request;
   payload.UnpackTo(&request);
 
@@ -49,7 +50,8 @@ PayloadOptional WarbleService::RegisterUser(const Payload &payload, const Storag
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::Follow(const Payload &payload, const StoragePtr &kv_store) {
+PayloadOptional WarbleService::Follow(const Payload &payload,
+                                      const StoragePtr &kv_store) {
   FollowRequest request;
   payload.UnpackTo(&request);
 
@@ -101,7 +103,8 @@ PayloadOptional WarbleService::Follow(const Payload &payload, const StoragePtr &
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::ReadProfile(const Payload &payload, const StoragePtr &kv_store) {
+PayloadOptional WarbleService::ReadProfile(const Payload &payload,
+                                           const StoragePtr &kv_store) {
   ProfileRequest request;
   payload.UnpackTo(&request);
 
@@ -153,7 +156,8 @@ PayloadOptional WarbleService::ReadProfile(const Payload &payload, const Storage
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::WarbleText(const Payload &payload, const StoragePtr &kv_store) {
+PayloadOptional WarbleService::WarbleText(const Payload &payload,
+                                          const StoragePtr &kv_store) {
   timeval time;
   gettimeofday(&time, NULL);
 
@@ -241,7 +245,8 @@ PayloadOptional WarbleService::WarbleText(const Payload &payload, const StorageP
   return PayloadOptional(reply_payload);
 }
 
-PayloadOptional WarbleService::ReadThread(const Payload &payload, const StoragePtr &kv_store) {
+PayloadOptional WarbleService::ReadThread(const Payload &payload,
+                                          const StoragePtr &kv_store) {
   ReadRequest request;
   payload.UnpackTo(&request);
   std::string warble_id = request.warble_id();

--- a/src/Warble/warble_service.h
+++ b/src/Warble/warble_service.h
@@ -1,6 +1,7 @@
 #ifndef CSCI499_FEI_SRC_WARBLE_WARBLE_SERVICE_H_
 #define CSCI499_FEI_SRC_WARBLE_WARBLE_SERVICE_H_
 
+#include "random_generator.h"
 #include "warble_service_abstraction.h"
 
 namespace cs499_fei {
@@ -42,20 +43,6 @@ class WarbleService : public WarbleServiceAbstraction {
   // Return the given user's following and followers
   PayloadOptional ReadProfile(const Payload &payload,
                               const StoragePtr &kv_store);
-
-  // Allow unit tests access private members
-  FRIEND_TEST(
-      WarbleTest,
-      shouldReturnNewWarbleWhenNewWarbleReplyToAnotherWarbleWithoutReplies);
-  FRIEND_TEST(
-      WarbleTest,
-      shouldReturnNewWarbleWhenNewWarbleReplyToAnotherWarbleWithReplies);
-
- private:
-  // Current warble id.
-  // Whenever create a new warble, assign this id to this new warble.
-  // Then increment by 1.
-  int warble_id_ = 1;
 };
 }  // namespace cs499_fei
 #endif  // CSCI499_FEI_SRC_WARBLE_WARBLE_SERVICE_H_

--- a/src/Warble/warble_service.h
+++ b/src/Warble/warble_service.h
@@ -20,26 +20,28 @@ class WarbleService : public WarbleServiceAbstraction {
   const std::string kInit = "INIT";
 
   // Constructor with the parameter of StoragePtr.
-  // StoragePtr used by Warble to communicate with KeyValueStore.
-  explicit WarbleService(const StoragePtr &storage_ptr)
-      : kv_store_(storage_ptr){};
+  explicit WarbleService(){};
 
   // Register the given user_name
-  PayloadOptional RegisterUser(const Payload &payload);
+  PayloadOptional RegisterUser(const Payload &payload,
+                               const StoragePtr &kv_store);
 
   // Post a new warble or post a new warble as a reply,
   // and return the id of the new warble.
-  PayloadOptional WarbleText(const Payload &payload);
+  PayloadOptional WarbleText(const Payload &payload,
+                             const StoragePtr &kv_store);
 
   // Start following a given user
-  PayloadOptional Follow(const Payload &payload);
+  PayloadOptional Follow(const Payload &payload, const StoragePtr &kv_store);
 
   // Read a warble thread from the given id.
   // Return the vector of the string serialization of Warble protobuf.
-  PayloadOptional ReadThread(const Payload &payload);
+  PayloadOptional ReadThread(const Payload &payload,
+                             const StoragePtr &kv_store);
 
   // Return the given user's following and followers
-  PayloadOptional ReadProfile(const Payload &payload);
+  PayloadOptional ReadProfile(const Payload &payload,
+                              const StoragePtr &kv_store);
 
   // Allow unit tests access private members
   FRIEND_TEST(
@@ -50,10 +52,6 @@ class WarbleService : public WarbleServiceAbstraction {
       shouldReturnNewWarbleWhenNewWarbleReplyToAnotherWarbleWithReplies);
 
  private:
-  // Pointer of storage abstraction.
-  // Used to access the KeyValue storage.
-  StoragePtr kv_store_;
-
   // Current warble id.
   // Whenever create a new warble, assign this id to this new warble.
   // Then increment by 1.

--- a/src/Warble/warble_service_abstraction.h
+++ b/src/Warble/warble_service_abstraction.h
@@ -44,21 +44,21 @@ class WarbleServiceAbstraction {
   virtual ~WarbleServiceAbstraction() = default;
 
   // Register the given user_name
-  virtual PayloadOptional RegisterUser(const Payload &payload) = 0;
+  virtual PayloadOptional RegisterUser(const Payload &payload, const StoragePtr &store) = 0;
 
   // Post a new warble or post a new warble as a reply,
   // and return the id of the new warble.
-  virtual PayloadOptional WarbleText(const Payload &payload) = 0;
+  virtual PayloadOptional WarbleText(const Payload &payload, const StoragePtr &store) = 0;
 
   // Start following a given user
-  virtual PayloadOptional Follow(const Payload &payload) = 0;
+  virtual PayloadOptional Follow(const Payload &payload, const StoragePtr &store) = 0;
 
   // Read a warble thread from the given id
   // Return the vector of the string serialization of Water protobuf
-  virtual PayloadOptional ReadThread(const Payload &payload) = 0;
+  virtual PayloadOptional ReadThread(const Payload &payload, const StoragePtr &store) = 0;
 
   // Return the given user's following and followers
-  virtual PayloadOptional ReadProfile(const Payload &payload) = 0;
+  virtual PayloadOptional ReadProfile(const Payload &payload, const StoragePtr &store) = 0;
 };
 }  // namespace cs499_fei
 #endif  // CSCI499_FEI_SRC_WARBLE_WARBLE_SERVICE_ABSTRACTION_H_

--- a/src/Warble/warble_service_abstraction.h
+++ b/src/Warble/warble_service_abstraction.h
@@ -44,21 +44,26 @@ class WarbleServiceAbstraction {
   virtual ~WarbleServiceAbstraction() = default;
 
   // Register the given user_name
-  virtual PayloadOptional RegisterUser(const Payload &payload, const StoragePtr &store) = 0;
+  virtual PayloadOptional RegisterUser(const Payload &payload,
+                                       const StoragePtr &store) = 0;
 
   // Post a new warble or post a new warble as a reply,
   // and return the id of the new warble.
-  virtual PayloadOptional WarbleText(const Payload &payload, const StoragePtr &store) = 0;
+  virtual PayloadOptional WarbleText(const Payload &payload,
+                                     const StoragePtr &store) = 0;
 
   // Start following a given user
-  virtual PayloadOptional Follow(const Payload &payload, const StoragePtr &store) = 0;
+  virtual PayloadOptional Follow(const Payload &payload,
+                                 const StoragePtr &store) = 0;
 
   // Read a warble thread from the given id
   // Return the vector of the string serialization of Water protobuf
-  virtual PayloadOptional ReadThread(const Payload &payload, const StoragePtr &store) = 0;
+  virtual PayloadOptional ReadThread(const Payload &payload,
+                                     const StoragePtr &store) = 0;
 
   // Return the given user's following and followers
-  virtual PayloadOptional ReadProfile(const Payload &payload, const StoragePtr &store) = 0;
+  virtual PayloadOptional ReadProfile(const Payload &payload,
+                                      const StoragePtr &store) = 0;
 };
 }  // namespace cs499_fei
 #endif  // CSCI499_FEI_SRC_WARBLE_WARBLE_SERVICE_ABSTRACTION_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(${BINARY} main.cc
         
         ${WARBLE_TEST_SOURCES}
         ${CMAKE_SOURCE_DIR}/src/Warble/warble_service.cc
+        ${CMAKE_SOURCE_DIR}/src/Warble/random_generator.cc
     )
 
 # link generated pb library

--- a/test/Func/func_service_test.cc
+++ b/test/Func/func_service_test.cc
@@ -23,11 +23,16 @@ class MockStorage : public StorageAbstraction {
 // Used for dependency injection for Func_platform constructor
 class MockWarble : public WarbleServiceAbstraction {
  public:
-  MOCK_METHOD2(RegisterUser, PayloadOptional(const Payload &payload, const StoragePtr &store));
-  MOCK_METHOD2(WarbleText, PayloadOptional(const Payload &payload, const StoragePtr &store));
-  MOCK_METHOD2(Follow, PayloadOptional(const Payload &payload, const StoragePtr &store));
-  MOCK_METHOD2(ReadThread, PayloadOptional(const Payload &payload, const StoragePtr &store));
-  MOCK_METHOD2(ReadProfile, PayloadOptional(const Payload &payload, const StoragePtr &store));
+  MOCK_METHOD2(RegisterUser, PayloadOptional(const Payload &payload,
+                                             const StoragePtr &store));
+  MOCK_METHOD2(WarbleText, PayloadOptional(const Payload &payload,
+                                           const StoragePtr &store));
+  MOCK_METHOD2(Follow, PayloadOptional(const Payload &payload,
+                                       const StoragePtr &store));
+  MOCK_METHOD2(ReadThread, PayloadOptional(const Payload &payload,
+                                           const StoragePtr &store));
+  MOCK_METHOD2(ReadProfile, PayloadOptional(const Payload &payload,
+                                            const StoragePtr &store));
 };
 
 // Init the global variables for all the test cases in this test suite
@@ -86,7 +91,7 @@ TEST_F(FuncPlatformTest, shouldCallRegisteruserWhenExectueEvent1) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, RegisterUser(_,_))
+  EXPECT_CALL(*mock_warble_, RegisterUser(_, _))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);
@@ -141,7 +146,7 @@ TEST_F(FuncPlatformTest, shouldCallReadThreadWhenExectueEvent4) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, ReadThread(_,_))
+  EXPECT_CALL(*mock_warble_, ReadThread(_, _))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);

--- a/test/Func/func_service_test.cc
+++ b/test/Func/func_service_test.cc
@@ -23,11 +23,11 @@ class MockStorage : public StorageAbstraction {
 // Used for dependency injection for Func_platform constructor
 class MockWarble : public WarbleServiceAbstraction {
  public:
-  MOCK_METHOD1(RegisterUser, PayloadOptional(const Payload &payload));
-  MOCK_METHOD1(WarbleText, PayloadOptional(const Payload &payload));
-  MOCK_METHOD1(Follow, PayloadOptional(const Payload &payload));
-  MOCK_METHOD1(ReadThread, PayloadOptional(const Payload &payload));
-  MOCK_METHOD1(ReadProfile, PayloadOptional(const Payload &payload));
+  MOCK_METHOD2(RegisterUser, PayloadOptional(const Payload &payload, const StoragePtr &store));
+  MOCK_METHOD2(WarbleText, PayloadOptional(const Payload &payload, const StoragePtr &store));
+  MOCK_METHOD2(Follow, PayloadOptional(const Payload &payload, const StoragePtr &store));
+  MOCK_METHOD2(ReadThread, PayloadOptional(const Payload &payload, const StoragePtr &store));
+  MOCK_METHOD2(ReadProfile, PayloadOptional(const Payload &payload, const StoragePtr &store));
 };
 
 // Init the global variables for all the test cases in this test suite
@@ -86,7 +86,7 @@ TEST_F(FuncPlatformTest, shouldCallRegisteruserWhenExectueEvent1) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, RegisterUser(_))
+  EXPECT_CALL(*mock_warble_, RegisterUser(_,_))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);
@@ -105,7 +105,7 @@ TEST_F(FuncPlatformTest, shouldCallWarbleTextWhenExectueEvent2) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, WarbleText(_))
+  EXPECT_CALL(*mock_warble_, WarbleText(_, _))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);
@@ -124,7 +124,7 @@ TEST_F(FuncPlatformTest, shouldCallFollowWhenExectueEvent3) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, Follow(_))
+  EXPECT_CALL(*mock_warble_, Follow(_, _))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);
@@ -141,7 +141,7 @@ TEST_F(FuncPlatformTest, shouldCallReadThreadWhenExectueEvent4) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, ReadThread(_))
+  EXPECT_CALL(*mock_warble_, ReadThread(_,_))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);
@@ -158,7 +158,7 @@ TEST_F(FuncPlatformTest, shouldCallReadProfileWhenExectueEvent5) {
   Payload payload, reply_payload;
   payload.PackFrom(request);
 
-  EXPECT_CALL(*mock_warble_, ReadProfile(_))
+  EXPECT_CALL(*mock_warble_, ReadProfile(_, _))
       .Times(1)
       .WillOnce(Return(reply_payload));
   PayloadOptional reply_payload_opt = service_->Execute(event_type, payload);

--- a/test/Warble/warble_service_test.cc
+++ b/test/Warble/warble_service_test.cc
@@ -7,6 +7,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "random_generator.h"
 #include "storage_abstraction.h"
 
 using ::testing::Return;
@@ -357,8 +358,8 @@ TEST_F(WarbleTest,
 
   std::string text = "It's my first warble.";
 
-  EXPECT_CALL(*mock_store_, Put("warble_1", testing::_));
-  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, "1"));
+  EXPECT_CALL(*mock_store_, Put(testing::_, testing::_));
+  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, testing::_));
 
   WarbleRequest request;
   request.set_username("Harry Potter");
@@ -378,7 +379,7 @@ TEST_F(WarbleTest,
 
   EXPECT_EQ(reply.mutable_warble()->username(), request.username());
   EXPECT_EQ(reply.mutable_warble()->text(), request.text());
-  EXPECT_EQ(reply.mutable_warble()->id(), "1");
+  EXPECT_FALSE(reply.mutable_warble()->id().empty());
   EXPECT_EQ(reply.mutable_warble()->parent_id(), request.parent_id());
 }
 
@@ -390,7 +391,6 @@ TEST_F(WarbleTest,
 TEST_F(WarbleTest,
        shouldReturnNewWarbleWhenNewWarbleReplyToAnotherWarbleWithoutReplies) {
   // mock warble id
-  warble_->warble_id_ = 100;
   std::string mock_user_warbles_key = "user_warbles_user_Harry Potter";
   std::string mock_warble_thread_key = "warble_thread_warble_3";
   std::string mock_warble_key = "warble_3";
@@ -404,9 +404,9 @@ TEST_F(WarbleTest,
 
   std::string text = "It's my second warble.";
 
-  EXPECT_CALL(*mock_store_, Put("warble_100", testing::_));
-  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, "1,100"));
-  EXPECT_CALL(*mock_store_, Put(mock_warble_thread_key, "100"));
+  EXPECT_CALL(*mock_store_, Put(testing::_, testing::_));
+  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, testing::_));
+  EXPECT_CALL(*mock_store_, Put(mock_warble_thread_key, testing::_));
 
   WarbleRequest request;
   request.set_username("Harry Potter");
@@ -427,7 +427,7 @@ TEST_F(WarbleTest,
 
   EXPECT_EQ(reply.mutable_warble()->username(), request.username());
   EXPECT_EQ(reply.mutable_warble()->text(), request.text());
-  EXPECT_EQ(reply.mutable_warble()->id(), "100");
+  EXPECT_FALSE(reply.mutable_warble()->id().empty());
   EXPECT_EQ(reply.mutable_warble()->parent_id(), request.parent_id());
 }
 
@@ -438,7 +438,6 @@ TEST_F(WarbleTest,
 TEST_F(WarbleTest,
        shouldReturnNewWarbleWhenNewWarbleReplyToAnotherWarbleWithReplies) {
   // mock warble id
-  warble_->warble_id_ = 100;
   std::string mock_user_warbles_key = "user_warbles_user_Harry Potter";
   std::string mock_warble_thread_key = "warble_thread_warble_3";
   std::string mock_warble_key = "warble_3";
@@ -452,9 +451,9 @@ TEST_F(WarbleTest,
 
   std::string text = "It's my second warble.";
 
-  EXPECT_CALL(*mock_store_, Put("warble_100", testing::_));
-  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, "1,100"));
-  EXPECT_CALL(*mock_store_, Put(mock_warble_thread_key, "4,5,6,100"));
+  EXPECT_CALL(*mock_store_, Put(testing::_, testing::_));
+  EXPECT_CALL(*mock_store_, Put(mock_user_warbles_key, testing::_));
+  EXPECT_CALL(*mock_store_, Put(mock_warble_thread_key, testing::_));
 
   WarbleRequest request;
   request.set_username("Harry Potter");
@@ -475,7 +474,7 @@ TEST_F(WarbleTest,
 
   EXPECT_EQ(reply.mutable_warble()->username(), request.username());
   EXPECT_EQ(reply.mutable_warble()->text(), request.text());
-  EXPECT_EQ(reply.mutable_warble()->id(), "100");
+  EXPECT_FALSE(reply.mutable_warble()->id().empty());
   EXPECT_EQ(reply.mutable_warble()->parent_id(), request.parent_id());
 }
 

--- a/test/Warble/warble_service_test.cc
+++ b/test/Warble/warble_service_test.cc
@@ -25,7 +25,7 @@ class MockStorage : public StorageAbstraction {
 class WarbleTest : public ::testing::Test {
  public:
   WarbleTest()
-      : mock_store_(new MockStorage), warble_(new WarbleService(mock_store_)) {}
+      : mock_store_(new MockStorage), warble_(new WarbleService()) {}
 
  protected:
   // dependencies
@@ -52,7 +52,7 @@ TEST_F(WarbleTest, shouldReturnPayloadWithValueWhenRegisterUserSuccessfully) {
   RegisteruserRequest mock_request;
   mock_request.set_username("Harry Potter");
   mock_payload.PackFrom(mock_request);
-  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload);
+  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload, mock_store_);
   EXPECT_TRUE(reply_payload.has_value());
 }
 
@@ -73,7 +73,7 @@ TEST_F(WarbleTest,
   RegisteruserRequest mock_request;
   mock_request.set_username("Harry Potter");
   mock_payload.PackFrom(mock_request);
-  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload);
+  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload.has_value());
 }
 
@@ -95,7 +95,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenCallFollowAndUserNameNotExist) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
 
@@ -117,7 +117,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenCallFollowAndToFollowNotExist) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
 
@@ -145,7 +145,7 @@ TEST_F(WarbleTest, shouldPayloadWithValueWhenCallFollowFirstTime) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload = warble_->Follow(mock_payload);
+  PayloadOptional reply_payload = warble_->Follow(mock_payload, mock_store_);
   EXPECT_TRUE(reply_payload.has_value());
 }
 
@@ -175,7 +175,7 @@ TEST_F(WarbleTest, shouldPayloadWithValueWhenCallFollow) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload = warble_->Follow(mock_payload);
+  PayloadOptional reply_payload = warble_->Follow(mock_payload, mock_store_);
   EXPECT_TRUE(reply_payload.has_value());
 }
 
@@ -198,7 +198,7 @@ TEST_F(
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -229,7 +229,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReadProfileOfAUserNotExist) {
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -260,7 +260,7 @@ TEST_F(WarbleTest,
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -304,7 +304,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenWarbleWithAUserNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -330,7 +330,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReplyToNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -359,7 +359,7 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -407,7 +407,7 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -454,7 +454,7 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -485,7 +485,7 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReadThreadNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -519,7 +519,7 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -598,7 +598,7 @@ TEST_F(
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload);
+  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();

--- a/test/Warble/warble_service_test.cc
+++ b/test/Warble/warble_service_test.cc
@@ -24,8 +24,7 @@ class MockStorage : public StorageAbstraction {
 // Init the global variables for all the test cases in this test suite
 class WarbleTest : public ::testing::Test {
  public:
-  WarbleTest()
-      : mock_store_(new MockStorage), warble_(new WarbleService()) {}
+  WarbleTest() : mock_store_(new MockStorage), warble_(new WarbleService()) {}
 
  protected:
   // dependencies
@@ -52,7 +51,8 @@ TEST_F(WarbleTest, shouldReturnPayloadWithValueWhenRegisterUserSuccessfully) {
   RegisteruserRequest mock_request;
   mock_request.set_username("Harry Potter");
   mock_payload.PackFrom(mock_request);
-  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload, mock_store_);
+  PayloadOptional reply_payload =
+      warble_->RegisterUser(mock_payload, mock_store_);
   EXPECT_TRUE(reply_payload.has_value());
 }
 
@@ -73,7 +73,8 @@ TEST_F(WarbleTest,
   RegisteruserRequest mock_request;
   mock_request.set_username("Harry Potter");
   mock_payload.PackFrom(mock_request);
-  PayloadOptional reply_payload = warble_->RegisterUser(mock_payload, mock_store_);
+  PayloadOptional reply_payload =
+      warble_->RegisterUser(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload.has_value());
 }
 
@@ -95,7 +96,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenCallFollowAndUserNameNotExist) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->Follow(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
 
@@ -117,7 +119,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenCallFollowAndToFollowNotExist) {
   request.set_username("Harry Potter");
   request.set_to_follow("Lord Voldmort");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->Follow(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->Follow(mock_payload, mock_store_);
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
 
@@ -198,7 +201,8 @@ TEST_F(
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadProfile(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -229,7 +233,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReadProfileOfAUserNotExist) {
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadProfile(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -260,7 +265,8 @@ TEST_F(WarbleTest,
   ProfileRequest request;
   request.set_username("Harry Potter");
   mock_payload.PackFrom(request);
-  PayloadOptional reply_payload_opt = warble_->ReadProfile(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadProfile(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -304,7 +310,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenWarbleWithAUserNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->WarbleText(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -330,7 +337,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReplyToNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->WarbleText(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -359,7 +367,8 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -407,7 +416,8 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -454,7 +464,8 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->WarbleText(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->WarbleText(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -485,7 +496,8 @@ TEST_F(WarbleTest, shouldReturnEmptyPayloadWhenReadThreadNotExist) {
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadThread(mock_payload, mock_store_);
 
   EXPECT_FALSE(reply_payload_opt.has_value());
 }
@@ -519,7 +531,8 @@ TEST_F(WarbleTest,
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadThread(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();
@@ -598,7 +611,8 @@ TEST_F(
   Payload mock_payload;
   mock_payload.PackFrom(request);
 
-  PayloadOptional reply_payload_opt = warble_->ReadThread(mock_payload, mock_store_);
+  PayloadOptional reply_payload_opt =
+      warble_->ReadThread(mock_payload, mock_store_);
 
   ASSERT_TRUE(reply_payload_opt.has_value());
   Payload reply_payload = reply_payload_opt.value();


### PR DESCRIPTION
To meet the requirement of ephemeral, two changes are done:
1. Directly pass storage pointer into each warble function instead of storing it as a member variable of warble class.
2. Substitute the incremental index for new warbles' index in warble class with a randomly generate id for each new warble.